### PR TITLE
Fix typo: "Names block" becomes "Named block"

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -35,7 +35,7 @@ Additionally, there are few jinja2 features not implemented in nunjucks:
 * `for` does not support `if not` and `else`
 * `with context` modifiers don't exist
 * `if i is divisibleby(3)`-style conditionals
-* Names block end tags: `{% endblock content %}`
+* Named block end tags: `{% endblock content %}`
 * Sandboxed mode
 * Line statements: `# for item in seq`
 


### PR DESCRIPTION
Simple fix. Seems legit. The in-browser editor in Github wants to add a newline at the file as well
