### PR TITLE
registerFilter > addFilter

### DIFF
--- a/api.md
+++ b/api.md
@@ -718,7 +718,7 @@ env.addFilter('lookup', function(name, callback) {
     db.getItem(name, callback);
 }, true);
 
-env.render('{{ item|lookup }}', function(err, res) {
+env.renderString('{{ item|lookup }}', function(err, res) {
     // do something with res
 });
 ```


### PR DESCRIPTION
I don't find the `registerFilter` method in `Environment`, I guess it should be `addFilter`.
