### PR TITLE
Change line 825 to parse until error or endremote

### DIFF
--- a/api.md
+++ b/api.md
@@ -822,7 +822,7 @@ function RemoteExtension() {
         parser.advanceAfterBlockEnd(tok.value);
 
         // parse the body and possibly the error block, which is optional
-        var body = parser.parseUntilBlocks('error', 'endtruncate');
+        var body = parser.parseUntilBlocks('error', 'endremote');
         var errorBody = null;
 
         if(parser.skipSymbol('error')) {


### PR DESCRIPTION
I'm not sure if `endtruncate` was intentional or not, but it seems to have no relavance in the example. When I remove the {% error %} tag that is supposed to be optional, the example crashes. If I replace 'endtruncate' with 'endremote' (line #850) it works.
