### PR TITLE
fix broken precompile link

### DIFF
--- a/api.md
+++ b/api.md
@@ -351,7 +351,7 @@ rendered.
 This loader also recognizes when precompiled templates are available
 and automatically uses them instead of fetching over HTTP. In
 production, this should always be the case. See
-[Precompiling Templates](#precompiling-templates).
+[Precompiling](#precompiling).
 
 ```js
 // Load templates from /views


### PR DESCRIPTION
Just fixed a broken link I happened to stumble upon using the docs.
All other instances use the `#precompiling` anchor, so I aligned to this convention.
